### PR TITLE
Scoring period typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The full rules of the Founding Member Program can be found [here](/RULES.md).
 
 ### Current Period
 
-The current [Scoring Period #5](/scoring-periods/6.md) started on the 26th of April, and ends on the 9th of May.
+The current [Scoring Period #6](/scoring-periods/6.md) started on the 26th of April, and ends on the 9th of May.
 
 <!--
 FIXME


### PR DESCRIPTION
There is a small typo in the "Current period" section:

"The current Scoring Period #5 started on the 26th of April, and ends on the 9th of May."

Should be fixed to "Scoring Period #6" as by dates and links it already refers to it